### PR TITLE
修复 Program::GetProperLoops 中传参数无效BUG

### DIFF
--- a/src/program.cc
+++ b/src/program.cc
@@ -77,7 +77,7 @@ LoopSet Program::GetElementaryLoops() const {
     LoopSet scc_checked;
     Hash hash;
     hash.AddLoops(scc);
-    
+
     while(! scc.empty()) {
         Loop* c = scc.front();
         bool is_elementary_loop = c->IsElementaryLoop();
@@ -89,10 +89,10 @@ LoopSet Program::GetElementaryLoops() const {
         else {
             scc_checked.push_back(c);//非elementary loop才需要销毁
         }
-        g_p->ExtendSccsFromInducedSubgraph(c, hash, scc, scc_checked);   
+        g_p->ExtendSccsFromInducedSubgraph(c, hash, scc, scc_checked);
         scc.pop_front();
     }
-    
+
     FreeLoops(scc_checked);//2-
     delete g_p;//1-
     return loops;
@@ -101,14 +101,17 @@ LoopSet Program::GetElementaryLoops() const {
 LoopSet Program::GetProperLoops(const AtomSet& atoms) const {
     assert(is_nlp());
     LoopSet loops;
-    Graph* g_p = GetDependencyGraph();//1+
+    Graph* depengdGraph =  GetDependencyGraph();
+
+    Graph* g_p = depengdGraph->GetInducedSubgraph(atoms);//1+
+
     LoopSet scc = g_p->GetSccs();//2+
     LoopSet scc_checked;
     Hash hash;
     hash.AddLoops(scc);
 
     while (! scc.empty()) {
-        Loop* c = scc.front(); 
+        Loop* c = scc.front();
         bool is_proper_loop = c->IsProperLoop(atoms);
 
         if (is_proper_loop) {
@@ -123,9 +126,10 @@ LoopSet Program::GetProperLoops(const AtomSet& atoms) const {
         }
         scc.pop_front();
     }
-    
+
     FreeLoops(scc_checked);
     delete g_p;//1-
+    delete depengdGraph;
     return loops;
 }
 
@@ -192,13 +196,13 @@ bool Program::ExistWeakElementaryLoop(const Loop& loop) const {
         FreeLoops(scc_r);
         delete g_r;
     }
-    
+
     FreeLoops(scc);
     delete g_p;
     return false;
 }
 /*
- * 
+ *
  */
 bool Program::IsHeadElementaryLoopFreeStar() const {
     AtomSet::const_iterator j;


### PR DESCRIPTION
## 修复错误
### 问题描述
GetProperLoops(const AtomSet& atoms) 不能根据参数 atoms 筛选普通逻辑程序中的特征环,函数固定输出 atoms 为普通逻辑程序全集时的特征环

### 复现
打开main.cc中宏 #define EL_PL_CMP
```
./dist/Debug/GNU-Linux-x86/properloops res/2_4_1 1
```
程序输出
```
elementary loop: 69
times: 0.137841

proper loop: 23
times: 0.053535
```

修改main.cc 52行, 即传入一个空集合
```
    LoopSet proper_loops = program.GetProperLoops({});
```
程序输出
```
elementary loop: 69
times: 0.130158

proper loop: 23
times: 0.013677
```

预期正确输出
```
...

proper loop: 0
...
```


修复后输出,与正确输出相同
```
elementary loop: 69
times: 0.126544

proper loop: 0
times: 0.000332
```



### 原因
这是修复前因为诱导子图 g_p 固定为正依赖图, 但是识别算法ProperLoops要求诱导子图g_p 为给定顶点集合atoms下的程序正依赖图的诱导子图.
